### PR TITLE
UI splitting experimens: EntriesView and QueryView

### DIFF
--- a/src/lib/systemd_journal/entries_dialog.rb
+++ b/src/lib/systemd_journal/entries_dialog.rb
@@ -18,12 +18,9 @@
 
 require "yast"
 require "ui/dialog"
+require "systemd_journal/entries_view"
 require "systemd_journal/query_presenter"
 require "systemd_journal/query_dialog"
-
-Yast.import "UI"
-Yast.import "Label"
-Yast.import "Popup"
 
 module SystemdJournal
   # Dialog to display journal entries with several filtering options
@@ -33,109 +30,38 @@ module SystemdJournal
       textdomain "systemd_journal"
 
       @query = QueryPresenter.new
-      @search = ""
-      read_journal_entries
+      execute_query
+      @view = EntriesView.new(@query)
     end
 
-    # Main dialog layout
     def dialog_content
-      VBox(
-        # Header
-        Heading(_("Journal entries")),
-        # Filters
-        Left(
-          HBox(
-            Label(_("Displaying entries with the following text")),
-            HSpacing(1),
-            InputField(Id(:search), Opt(:hstretch, :notify), "", @search)
-          )
-        ),
-        ReplacePoint(Id(:query), query_description),
-        VSpacing(0.3),
-        # Log entries
-        table,
-        VSpacing(0.3),
-        # Footer buttons
-        footer
-      )
+      @view.content
     end
 
-    # Dialog options
     def dialog_options
-      Opt(:decorated, :defaultsize)
+      @view.dialog_options
     end
 
     # Event callback for the 'change filter' button.
     def filter_handler
       return unless read_query
-      read_journal_entries
-      redraw_query
-      redraw_table
+      @view.redraw_query
+      execute_query
+      @view.redraw_table
     end
 
     # Event callback for change in the content of the search box
     def search_handler
-      read_search
-      redraw_table
+      @view.redraw_table
     end
 
     # Event callback for the 'refresh' button
     def refresh_handler
-      read_journal_entries
-      redraw_table
+      execute_query
+      @view.redraw_table
     end
 
     private
-
-    # Table widget (plus wrappers) to display log entries
-    def table
-      headers = @query.columns.map { |c| c[:label] }
-
-      Table(
-        Id(:table),
-        Opt(:keepSorting),
-        Header(*headers),
-        table_items
-      )
-    end
-
-    def table_items
-      # Reduce it to an array with only the visible fields
-      entries_fields = @journal_entries.map do |entry|
-        @query.columns.map { |c| entry.send(c[:method]) }
-      end
-      # Grep for entries matching @search in any visible field
-      entries_fields.select! do |fields|
-        fields.any? { |f| Regexp.new(@search, Regexp::IGNORECASE).match(f) }
-      end
-      # Return the result as an array of Items
-      entries_fields.map { |fields| Item(*fields) }
-    end
-
-    def footer
-      HBox(
-        HWeight(1, PushButton(Id(:filter), _("Change filter..."))),
-        HStretch(),
-        HWeight(1, PushButton(Id(:refresh), _("Refresh"))),
-        HStretch(),
-        HWeight(1, PushButton(Id(:cancel), Yast::Label.QuitButton))
-      )
-    end
-
-    def query_description
-      VBox(
-        Left(Label(" - #{@query.interval_description}")),
-        Left(Label(" - #{@query.filters_description}"))
-      )
-    end
-
-    def redraw_query
-      Yast::UI.ReplaceWidget(Id(:query), query_description)
-    end
-
-    def redraw_table
-      Yast::UI.ChangeWidget(Id(:table), :Items, table_items)
-    end
 
     # Asks the user the new query options using SystemdJournal::QueryDialog.
     #
@@ -146,6 +72,7 @@ module SystemdJournal
       query = QueryDialog.new(@query).run
       if query
         @query = query
+        @view.query = query
         log.info "New query is #{@query}."
         true
       else
@@ -154,21 +81,13 @@ module SystemdJournal
       end
     end
 
-    # Gets the new search string from the interface
-    def read_search
-      @search = Yast::UI.QueryWidget(Id(:search), :Value)
-      log.info "Search string set to '#{@search}'"
-    end
-
     # Reads the journal entries from the system
-    def read_journal_entries
-      log.info "Calling journalctl with #{@query.journalctl_options} "\
-        "and #{@query.journalctl_matches}"
-      @journal_entries = @query.entries
-      log.info "Call to journalctl returned #{@journal_entries.size} entries."
+    def execute_query
+      log.info "Executing query #{@query}"
+      @query.execute
+      log.info "Call to journalctl returned #{@query.entries.size} entries."
     rescue => e
       log.warn e.message
-      @journal_entries = []
       Yast::Popup.Message(e.message)
     end
   end

--- a/src/lib/systemd_journal/entries_view.rb
+++ b/src/lib/systemd_journal/entries_view.rb
@@ -1,0 +1,114 @@
+# Copyright (c) 2014 SUSE LLC.
+#  All Rights Reserved.
+
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of version 2 or 3 of the GNU General
+#  Public License as published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+#  GNU General Public License for more details.
+
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, contact SUSE LLC.
+
+#  To contact SUSE about this file by physical or electronic mail,
+#  you may find current contact information at www.suse.com
+
+Yast.import "UI"
+Yast.import "Label"
+Yast.import "Popup"
+
+module SystemdJournal
+  class EntriesView
+    include Yast::UIShortcuts
+    include Yast::I18n
+
+    attr_writer :query
+
+    def initialize(query)
+      @query = query
+    end
+
+    # Main dialog layout
+    def content
+      VBox(
+        # Header
+        Heading(_("Journal entries")),
+        # Filters
+        Left(
+          HBox(
+            Label(_("Displaying entries with the following text")),
+            HSpacing(1),
+            InputField(Id(:search), Opt(:hstretch, :notify), "", "")
+          )
+        ),
+        ReplacePoint(Id(:query), query_description),
+        VSpacing(0.3),
+        # Log entries
+        table,
+        VSpacing(0.3),
+        # Footer buttons
+        footer
+      )
+    end
+
+    # Dialog options
+    def dialog_options
+      Opt(:decorated, :defaultsize)
+    end
+
+    # Table widget (plus wrappers) to display log entries
+    def table
+      headers = @query.columns.map { |c| c[:label] }
+
+      Table(
+        Id(:table),
+        Opt(:keepSorting),
+        Header(*headers),
+        table_items
+      )
+    end
+
+    def table_items
+      search = Yast::UI.QueryWidget(Id(:search), :Value) || ""
+
+      # Reduce it to an array with only the visible fields
+      entries_fields = @query.entries.map do |entry|
+        @query.columns.map { |c| entry.send(c[:method]) }
+      end
+      # Grep for entries matching 'search' in any visible field
+      entries_fields.select! do |fields|
+        fields.any? { |f| Regexp.new(search, Regexp::IGNORECASE).match(f) }
+      end
+      # Return the result as an array of Items
+      entries_fields.map { |fields| Item(*fields) }
+    end
+
+    def footer
+      HBox(
+        HWeight(1, PushButton(Id(:filter), _("Change filter..."))),
+        HStretch(),
+        HWeight(1, PushButton(Id(:refresh), _("Refresh"))),
+        HStretch(),
+        HWeight(1, PushButton(Id(:cancel), Yast::Label.QuitButton))
+      )
+    end
+
+    def query_description
+      VBox(
+        Left(Label(" - #{@query.interval_description}")),
+        Left(Label(" - #{@query.filters_description}"))
+      )
+    end
+
+    def redraw_query
+      Yast::UI.ReplaceWidget(Id(:query), query_description)
+    end
+
+    def redraw_table
+      Yast::UI.ChangeWidget(Id(:table), :Items, table_items)
+    end
+  end
+end

--- a/src/lib/systemd_journal/query.rb
+++ b/src/lib/systemd_journal/query.rb
@@ -31,6 +31,7 @@ module SystemdJournal
     # @return [Array] matches in the format expected by Journalctl
     # @see SystemdJournal::Journalctl#initialize
     attr_reader :journalctl_matches
+    attr_reader :entries
 
     # Creates a new query based on the time interval and some additional filters
     #
@@ -58,17 +59,22 @@ module SystemdJournal
       else
         @journalctl_matches = [filters["match"]].flatten
       end
-
       calculate_options
+
+      @entries = []
     end
 
-    # Calls journalctl and returns an Array of Entry objects
-    def entries
-      Entry.all(options: journalctl_options, matches: journalctl_matches)
+    # Calls journalctl and XXX Array of Entry objects
+    def execute
+      @entries = Entry.all(
+        options: journalctl_options,
+        matches: journalctl_matches
+      )
     end
 
     def to_s
-      "<interval: #{@interval}, filters: #{@filters}>"
+      "<interval: #{@interval}, filters: #{@filters}, journalctl_options: "\
+        "#{@journalctl_options}, journalctl_matches #{@journalctl_matches}>"
     end
 
     # Array of system's boots registered in the journal.

--- a/src/lib/systemd_journal/query_dialog.rb
+++ b/src/lib/systemd_journal/query_dialog.rb
@@ -18,11 +18,8 @@
 
 require "yast"
 require "ui/dialog"
-require "systemd_journal/time_helpers"
+require "systemd_journal/query_view"
 require "systemd_journal/query_presenter"
-
-Yast.import "UI"
-Yast.import "Label"
 
 module SystemdJournal
   # Dialog allowing the user to set the query used to display the journal
@@ -32,179 +29,38 @@ module SystemdJournal
   #
   # @see SystemdJournal::EntriesDialog
   class QueryDialog < UI::Dialog
-    include TimeHelpers
-
-    INPUT_WIDTH = 20
-
     def initialize(query)
       super()
       textdomain "systemd_journal"
       @query = query
+      @view = QueryView.new(@query)
     end
 
-    # Main layout
     def dialog_content
-      VBox(
-        # Header
-        Heading(_("Entries to display")),
-        # Interval
-        Frame(
-          _("Time interval"),
-          interval_widget
-        ),
-        VSpacing(0.3),
-        # Filters
-        Frame(
-          _("Filters"),
-          filters_widget
-        ),
-        VSpacing(0.3),
-        # Footer buttons
-        HBox(
-          PushButton(Id(:cancel), Yast::Label.CancelButton),
-          PushButton(Id(:ok), Yast::Label.OKButton)
-        )
-      )
+      @view.content
     end
 
     # Event callback for the 'ok' button
     def ok_handler
-      finish_dialog(query_from_widgets)
+      finish_dialog(query_from_view)
     end
 
     private
 
     # Translates the value of the widgets to a new QueryPresenter object
-    def query_from_widgets
-      interval = Yast::UI.QueryWidget(Id(:interval), :CurrentButton)
-      if interval == "Hash"
-        interval = {
-          since: time_from_widgets_for(:since),
-          until: time_from_widgets_for(:until)
-        }
-      end
+    def query_from_view
+      interval = @view.interval
 
       filters = {}
       QueryPresenter.filters.each do |filter|
         name = filter[:name]
-        # Skip if the checkbox is not checked
-        next unless Yast::UI.QueryWidget(Id(name), :Value)
         # Read the widget...
-        value = widget_to_filter(name, filter[:multiple])
+        value = @view.filter(name, filter[:multiple])
         # ...discarding empty values
         filters[name] = value unless value.empty?
       end
 
       QueryPresenter.new(interval: interval, filters: filters)
-    end
-
-    def interval_widget
-      RadioButtonGroup(Id(:interval), VBox(*interval_buttons))
-    end
-
-    # Array of radio buttons to select the interval
-    def interval_buttons
-      QueryPresenter.intervals.map do |int|
-        selected = int[:value] === @query.interval
-        value = int[:value].to_s
-        widgets = [RadioButton(Id(value), int[:label], selected)]
-        if value == "Hash"
-          widgets << HSpacing(1)
-          widgets.concat(dates_widgets)
-        end
-
-        Left(HBox(*widgets))
-      end
-    end
-
-    # Array of widgets for selecting date/time thresholds
-    def dates_widgets
-      [
-        *time_widgets_for(:since, since_value),
-        Label("-"),
-        *time_widgets_for(:until, until_value)
-      ]
-    end
-
-    # Initial value for the :since widget
-    def since_value
-      if @query.interval.is_a?(Hash)
-        @query.interval[:since]
-      else
-        QueryPresenter.default_since
-      end
-    end
-
-    # Initial value for the :until widget
-    def until_value
-      if @query.interval.is_a?(Hash)
-        @query.interval[:until]
-      else
-        QueryPresenter.default_until
-      end
-    end
-
-    # Widget allowing to set the filters
-    def filters_widget
-      filters = QueryPresenter.filters.map do |filter|
-        name = filter[:name]
-        Left(
-          HBox(
-            CheckBox(Id(name), filter[:label], !@query.filters[name].nil?),
-            HSpacing(1),
-            widget_for_filter(name, filter[:values])
-          )
-        )
-      end
-      VBox(*filters)
-    end
-
-    # Widget to set the value of a given filter.
-    #
-    # If the second argument is nil, an input field will be used. Otherwise, a
-    # combo box will be returned.
-    #
-    # @param name [Symbol] name of the filter
-    # @param values [Array] optional list of values for the combo box
-    def widget_for_filter(name, values = nil)
-      id = Id(:"#{name}_value")
-      if values
-        items = values.map do |value|
-          Item(Id(value), value, @query.filters[name] == value)
-        end
-        ComboBox(id, "", items)
-      else
-        MinWidth(INPUT_WIDTH, InputField(id, "", filter_to_string(name)))
-      end
-    end
-
-    # String representing the value of a filter.
-    #
-    # Used to fill the corresponding input field. If the filter has multiple
-    # values, they will be concatenated with a whitespace as separator.
-    def filter_to_string(name)
-      value = @query.filters[name]
-      if value.nil?
-        ""
-      elsif value.is_a?(Array)
-        value.join(" ")
-      else
-        value
-      end
-    end
-
-    # Reads the widget associated to a filter and returns its value, as
-    # a String or an Array of strings.
-    #
-    # @param name [Symbol] name of the filter
-    # @param multiple [Boolean] if true, an array will be returned
-    def widget_to_filter(name, multiple)
-      value = Yast::UI.QueryWidget(Id(:"#{name}_value"), :Value)
-      if multiple
-        value.split(" ")
-      else
-        value
-      end
     end
   end
 end

--- a/src/lib/systemd_journal/query_view.rb
+++ b/src/lib/systemd_journal/query_view.rb
@@ -1,0 +1,204 @@
+# Copyright (c) 2014 SUSE LLC.
+#  All Rights Reserved.
+
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of version 2 or 3 of the GNU General
+#  Public License as published by the Free Software Foundation.
+
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.   See the
+#  GNU General Public License for more details.
+
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, contact SUSE LLC.
+
+#  To contact SUSE about this file by physical or electronic mail,
+#  you may find current contact information at www.suse.com
+
+require "systemd_journal/time_helpers"
+
+Yast.import "Label"
+Yast.import "UI"
+
+module SystemdJournal
+  class QueryView
+    include TimeHelpers
+    include Yast::UIShortcuts
+    include Yast::I18n
+
+    INPUT_WIDTH = 20
+
+    def initialize(query)
+      @query = query
+    end
+
+    # Reads the widget associated to a filter and returns its value, as
+    # a String or an Array of strings.
+    #
+    # @param name [Symbol] name of the filter
+    # @param multiple [Boolean] if true, an array will be returned
+    def filter(name, multiple)
+      # Is the checkbox checked?
+      return "" unless Yast::UI.QueryWidget(Id(name), :Value)
+      value = Yast::UI.QueryWidget(Id(:"#{name}_value"), :Value)
+      if multiple
+        value.split(" ")
+      else
+        value
+      end
+    end
+
+    def interval
+      interval = Yast::UI.QueryWidget(Id(:interval), :CurrentButton)
+      if interval == "Hash"
+        interval = {
+          since: time_from_widgets_for(:since),
+          until: time_from_widgets_for(:until)
+        }
+      end
+      interval
+    end
+
+    # Main layout
+    def content
+      VBox(
+        # Header
+        Heading(_("Entries to display")),
+        # Interval
+        Frame(
+          _("Time interval"),
+          interval_widget
+        ),
+        VSpacing(0.3),
+        # Filters
+        Frame(
+          _("Filters"),
+          filters_widget
+        ),
+        VSpacing(0.3),
+        # Footer buttons
+        HBox(
+          PushButton(Id(:cancel), Yast::Label.CancelButton),
+          PushButton(Id(:ok), Yast::Label.OKButton)
+        )
+      )
+    end
+
+    private
+
+    def interval_widget
+      RadioButtonGroup(Id(:interval), VBox(*interval_buttons))
+    end
+
+    # Array of radio buttons to select the interval
+    def interval_buttons
+      QueryPresenter.intervals.map do |int|
+        selected = int[:value] === @query.interval
+        value = int[:value].to_s
+        widgets = [RadioButton(Id(value), int[:label], selected)]
+        if value == "Hash"
+          widgets << HSpacing(1)
+          widgets.concat(dates_widgets)
+        end
+
+        Left(HBox(*widgets))
+      end
+    end
+
+    # Array of widgets for selecting date/time thresholds
+    def dates_widgets
+      [
+        *time_widgets_for(:since, since_value),
+        Label("-"),
+        *time_widgets_for(:until, until_value)
+      ]
+    end
+
+    # Widget allowing to set the filters
+    def filters_widget
+      filters = QueryPresenter.filters.map do |filter|
+        name = filter[:name]
+        Left(
+          HBox(
+            CheckBox(Id(name), filter[:label], !@query.filters[name].nil?),
+            HSpacing(1),
+            widget_for_filter(name, filter[:values])
+          )
+        )
+      end
+      VBox(*filters)
+    end
+
+    # Widget to set the value of a given filter.
+    #
+    # If the second argument is nil, an input field will be used. Otherwise, a
+    # combo box will be returned.
+    #
+    # @param name [Symbol] name of the filter
+    # @param values [Array] optional list of values for the combo box
+    def widget_for_filter(name, values = nil)
+      id = Id(:"#{name}_value")
+      if values
+        items = values.map do |value|
+          Item(Id(value), value, @query.filters[name] == value)
+        end
+        ComboBox(id, "", items)
+      else
+        MinWidth(INPUT_WIDTH, InputField(id, "", filter_to_string(name)))
+      end
+    end
+
+    # Initial value for the :since widget
+    def since_value
+      if @query.interval.is_a?(Hash)
+        @query.interval[:since]
+      else
+        QueryPresenter.default_since
+      end
+    end
+
+    # Initial value for the :until widget
+    def until_value
+      if @query.interval.is_a?(Hash)
+        @query.interval[:until]
+      else
+        QueryPresenter.default_until
+      end
+    end
+
+    # Widget to set the value of a given filter.
+    #
+    # If the second argument is nil, an input field will be used. Otherwise, a
+    # combo box will be returned.
+    #
+    # @param name [Symbol] name of the filter
+    # @param values [Array] optional list of values for the combo box
+    def widget_for_filter(name, values = nil)
+      id = Id(:"#{name}_value")
+      if values
+        items = values.map do |value|
+          Item(Id(value), value, @query.filters[name] == value)
+        end
+        ComboBox(id, "", items)
+      else
+        MinWidth(INPUT_WIDTH, InputField(id, "", filter_to_string(name)))
+      end
+    end
+
+    # String representing the value of a filter.
+    #
+    # Used to fill the corresponding input field. If the filter has multiple
+    # values, they will be concatenated with a whitespace as separator.
+    def filter_to_string(name)
+      value = @query.filters[name]
+      if value.nil?
+        ""
+      elsif value.is_a?(Array)
+        value.join(" ")
+      else
+        value
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is just an experiment. The inline documentation is wrong/missing in several points and the tests are broken.

I wanted to introduce some clear separation between the event loop and the drawing/reading of widgets. In the case of EntriesDialog, there is no much gain but the result is not that bad. In the case of QueryDialog (a quite dumb dialog that only displays and reads a form) it only adds complexity.

As solution, is not really worthy. As experiment I believe it's interesting.